### PR TITLE
Updates to use Electron 11 and the latest infusion-electron.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-target=6.0.8
+target=11.1.0
 disturl=https://atom.io/download/electron
 runtime=electron
 build_from_source=true

--- a/gridquencer-app.js
+++ b/gridquencer-app.js
@@ -1,20 +1,16 @@
 "use strict";
 
-var fluid = require("infusion");
+var fluid = require("infusion"),
+    gridquencer = fluid.registerNamespace("gridquencer");
 
 fluid.defaults("gridquencer.app", {
     gradeNames: "electron.app",
-    model: {
-        commandLineSwitches: {
-            expander: {
-                funcName: "fluid.stringTemplate",
-                args: [
-                    "autoplay-policy", 
-                    "no-user-gesture-required"
-                ]
-            }
-        }
+
+    commandLineSwitches: {
+        "autoplay-policy": null,
+        "no-user-gesture-required": null
     },
+
     components: {
         mainWindow: {
             createOnEvent: "onReady",
@@ -27,8 +23,9 @@ fluid.defaults("gridquencer.app", {
                     x: 100,
                     y: 100,
                     webPreferences: {
-                        nodeIntegration: true
-                    },
+                        nodeIntegration: true,
+                        contextIsolation: false
+                    }
                 },
                 model: {
                     url: {
@@ -41,21 +38,18 @@ fluid.defaults("gridquencer.app", {
                         }
                     }
                 }
-            },
-        },
+            }
+        }
     },
 
-    /*
     listeners: {
-        onReady: {
-            func: function(app){
-                app.allowRendererProcessReuse = false;
-                console.log(app);
-            },
+        "onCreate.disableProcessReuse": {
+            funcName: "gridquencer.app.disableProcessReuse",
             args: ["{that}.app"]
         }
     }
-    */
 });
 
-
+gridquencer.app.disableProcessReuse = function (electronApp) {
+    electronApp.allowRendererProcessReuse = false;
+};

--- a/main-window.html
+++ b/main-window.html
@@ -34,7 +34,7 @@
               pushDisplay.sendFrame(ctx, function(error) {
                 console.log("called sendFrame()");
                 requestAnimationFrame(nextFrame);
-              })
+              });
             }
 
             pushDisplay.initPush(function (err) {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "ableton-push-canvas-display": "1.0.1",
         "flocking": "3.0.0-dev.20201125T044807Z.e93e401",
         "flocking-midi": "1.0.0-dev.20200715T193144Z.94cf29b.gh-30",
-        "infusion-electron": "0.7.0",
-        "electron": "6.0.8"
+        "infusion-electron": "0.8.0",
+        "electron": "11.1.1"
     },
     "scripts": {
         "start": "node_modules/.bin/electron ."


### PR DESCRIPTION
This seems to work with the latest version of Electron and the new release of infusion-electron. I expect this will be the last version that will be viable using this technique.

Perhaps the <code>usb</code> native module will be eventually be updated to be context aware, but it appears to be woefully under-maintained. You might get some mileage by sending the image data from the Renderer process to the Main process, though I worry that Node.js itself may eventually deprecate non-context aware modules before too long. Who knows, but for now this should work.